### PR TITLE
Feature/blacklist

### DIFF
--- a/src/main/java/com/xwaffle/universalmarket/commands/MarketCommand.java
+++ b/src/main/java/com/xwaffle/universalmarket/commands/MarketCommand.java
@@ -151,6 +151,11 @@ public class MarketCommand extends BasicCommand {
                             }
                         }
 
+                        if (UniversalMarket.getInstance().getMarket().isItemBlacklisted(stack.getType())) {
+                            player.sendMessage(Text.of(TextColors.RED, "This item cannot be sold (" + stack.getType().getId() + ")"));
+                            return CommandResult.success();
+                        }
+
 
                         int prevAmount = stack.getQuantity();
 

--- a/src/main/java/com/xwaffle/universalmarket/config/MarketConfig.java
+++ b/src/main/java/com/xwaffle/universalmarket/config/MarketConfig.java
@@ -12,6 +12,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
+import java.util.ArrayList;
 
 /**
  * Created by Chase(Xwaffle) on 10/15/2017.
@@ -90,7 +91,7 @@ public class MarketConfig implements Configurable {
         get().getNode(new Object[]{"Market", "market-price"}).setValue(1000).setComment("Instead of taxing, take a flat amount of the user before they can sell.");
         get().getNode(new Object[]{"Market", "use-permissions-to-sell"}).setValue(false).setComment("You can give permissions for the amount of items a user can sell. com.xwaffle.universalmarket.addmax.3 allows 3 items for the user");
 
-
+        get().getNode(new Object[]{"Market", "blacklist"}).setValue(new ArrayList<String>()).setComment("Items that users can not sell");
     }
 
     public CommentedConfigurationNode get() {

--- a/src/main/java/com/xwaffle/universalmarket/market/Market.java
+++ b/src/main/java/com/xwaffle/universalmarket/market/Market.java
@@ -13,6 +13,7 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContext;
 import org.spongepowered.api.event.item.inventory.ClickInventoryEvent;
+import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.InventoryProperty;
@@ -102,8 +103,8 @@ public class Market {
 
 //    private int marketID = -1;
 
-    public boolean isItemBlacklisted(MarketItem marketItem) {
-        return blacklist.contains(marketItem.toString());
+    public boolean isItemBlacklisted(ItemType itemType) {
+        return blacklist.contains(itemType.getId());
     }
 
     public void addItem(MarketItem marketItem, boolean addToDB) {

--- a/src/main/java/com/xwaffle/universalmarket/market/Market.java
+++ b/src/main/java/com/xwaffle/universalmarket/market/Market.java
@@ -45,6 +45,7 @@ public class Market {
     private double tax = 0.20; //20% of the item.
     private int flatPrice = 1000;
     private boolean usePermissionToSell = false;
+    private List<String> blacklist;
 
     private boolean useFKey = false;
 

--- a/src/main/java/com/xwaffle/universalmarket/market/Market.java
+++ b/src/main/java/com/xwaffle/universalmarket/market/Market.java
@@ -102,6 +102,10 @@ public class Market {
 
 //    private int marketID = -1;
 
+    public boolean isItemBlacklisted(MarketItem marketItem) {
+        return blacklist.contains(marketItem.toString());
+    }
+
     public void addItem(MarketItem marketItem, boolean addToDB) {
         if (addToDB) {
             //Adds Item to DB.

--- a/src/main/java/com/xwaffle/universalmarket/market/Market.java
+++ b/src/main/java/com/xwaffle/universalmarket/market/Market.java
@@ -1,10 +1,12 @@
 package com.xwaffle.universalmarket.market;
 
 import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
 import com.xwaffle.universalmarket.UniversalMarket;
 import com.xwaffle.universalmarket.utils.InventoryBuilder;
 import com.xwaffle.universalmarket.utils.ItemBuilder;
 import net.minecraft.nbt.NBTTagCompound;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.type.DyeColors;
 import org.spongepowered.api.entity.living.player.Player;
@@ -86,6 +88,11 @@ public class Market {
         this.payFlatPrice = UniversalMarket.getConfig().get().getNode("Market", "pay-to-sell").getBoolean();
         this.flatPrice = UniversalMarket.getConfig().get().getNode("Market", "market-price").getInt();
         this.usePermissionToSell = UniversalMarket.getConfig().get().getNode("Market", "use-permissions-to-sell").getBoolean();
+        try {
+            this.blacklist = UniversalMarket.getConfig().get().getNode("Market", "blacklist").getList(TypeToken.of(String.class));
+        } catch (ObjectMappingException e) {
+            this.blacklist = new ArrayList<String>();
+        }
 
         this.useFKey = UniversalMarket.getConfig().get().getNode("Market", "f-key-open-market").getBoolean();
 

--- a/src/main/java/com/xwaffle/universalmarket/market/MarketItem.java
+++ b/src/main/java/com/xwaffle/universalmarket/market/MarketItem.java
@@ -77,7 +77,7 @@ public class MarketItem {
     }
 
     public boolean isBlacklisted() {
-        return UniversalMarket.getInstance().getMarket().isItemBlacklisted(this);
+        return UniversalMarket.getInstance().getMarket().isItemBlacklisted(item.getType());
     }
 
     public void setDatabaseID(int ID) {

--- a/src/main/java/com/xwaffle/universalmarket/market/MarketItem.java
+++ b/src/main/java/com/xwaffle/universalmarket/market/MarketItem.java
@@ -76,6 +76,10 @@ public class MarketItem {
         this.item = ItemSerialization.deserializeItemStack(data).get();
     }
 
+    public boolean isBlacklisted() {
+        return UniversalMarket.getInstance().getMarket().isItemBlacklisted(this);
+    }
+
     public void setDatabaseID(int ID) {
         this.databaseID = ID;
     }


### PR DESCRIPTION
Hi.
I love this plugin!
I have a request for a feature that prevents users selling specific types of items.
In other words, a blacklist.
So I implemented it.

This pull request suppose to:
+ Enable the server owner to specify multiple item types that he/she doesn't want players to sell
+ Prevent players adding blacklisted items to the market via the command: `/um add`

If you like this idea, please merge this request.
Thank you.